### PR TITLE
remove unintended capture bs

### DIFF
--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -175,7 +175,6 @@ class CudaGraphRunner:
 
         # Batch sizes to capture
         self.capture_bs, self.compile_bs = get_batch_sizes_to_capture(model_runner)
-        print(self.capture_bs)
         self.capture_forward_mode = ForwardMode.DECODE
         self.num_tokens_per_bs = 1
         if model_runner.spec_algorithm.is_eagle():

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -114,6 +114,8 @@ def get_batch_sizes_to_capture(model_runner: ModelRunner):
             capture_bs = list(range(1, 33)) + [64, 128]
         else:
             capture_bs = [1, 2, 4] + [i * 8 for i in range(1, 21)]
+            if is_hip_:
+                capture_bs += [i * 8 for i in range(21, 33)]
     if max(capture_bs) > model_runner.req_to_token_pool.size:
         # In some case (e.g., with a small GPU or --max-running-requests), the #max-running-requests
         # is very samll. We add more values here to make sure we capture the maximum bs.
@@ -132,8 +134,6 @@ def get_batch_sizes_to_capture(model_runner: ModelRunner):
         if bs <= model_runner.req_to_token_pool.size
         and bs <= server_args.cuda_graph_max_bs
     ]
-    if is_hip_:
-        capture_bs += [i * 8 for i in range(21, 33)]
     compile_bs = (
         [bs for bs in capture_bs if bs <= server_args.torch_compile_max_bs]
         if server_args.enable_torch_compile
@@ -175,6 +175,7 @@ class CudaGraphRunner:
 
         # Batch sizes to capture
         self.capture_bs, self.compile_bs = get_batch_sizes_to_capture(model_runner)
+        print(self.capture_bs)
         self.capture_forward_mode = ForwardMode.DECODE
         self.num_tokens_per_bs = 1
         if model_runner.spec_algorithm.is_eagle():


### PR DESCRIPTION
## Motivation

The original code always captures the unintended large size of batch size when `is_hip()` returns true. So it was ignore `--cuda-capture-bs` argument in `sglang.launch_server` so I fixed it. 

Related HiP Attention PR: https://github.com/DeepAuto-AI/hip-attention/pull/45

## Modifications

Move manually defined capture BS modification inside the condition.
